### PR TITLE
fix: iOS Safari crash fix

### DIFF
--- a/app/components/App.tsx
+++ b/app/components/App.tsx
@@ -47,7 +47,11 @@ const App: () => JSX.Element = () => {
     if (!connection) return;
 
     const onData = (e: BlobEvent) => {
-      connection?.send(e.data);
+      // iOS SAFARI FIX:
+      // Prevent packetZero from being sent. If sent at size 0, the connection will close. 
+      if (e.data.size > 0) {
+        connection?.send(e.data);
+      }
     };
 
     const onTranscript = (data: LiveTranscriptionEvent) => {


### PR DESCRIPTION
When using Safari on iOS, an empty packet is sent within the first few seconds of connecting. This causes the connection to close. By checking that e.data.size > 0, we only send packets with data to the Deepgram API, preventing this from happening.

This has been an outstanding problem on discord and on github:

**Github**: 
- https://github.com/orgs/deepgram/discussions/557

**Discord**: 
- https://discord.com/channels/1108042150941294664/1233797369888243735
- https://discord.com/channels/1108042150941294664/1227695843721613413
- https://discord.com/channels/1108042150941294664/1216221153786466334
- https://discord.com/channels/1108042150941294664/1207101720291844178